### PR TITLE
Added .ssh folder

### DIFF
--- a/scripts/install_github.sh
+++ b/scripts/install_github.sh
@@ -5,5 +5,6 @@ chmod 600 /root/github_key
 cp $folder/.gitconfig /root/.gitconfig
 chmod 600 /root/.gitconfig
 
+mkdir -p /root/.ssh
 cp $folder/ssh_config /root/.ssh/config
-chmod 600 /root/.ssh/config
+chmod 600 -R /root/.ssh/


### PR DESCRIPTION
If I run the install script, I get an error about a missing directory (http://prntscr.com/m8ndto). I tweaked the script to build out the .ssh folder.