### PR TITLE
Update start --build sv command to build only directories.

### DIFF
--- a/sv/sv.js
+++ b/sv/sv.js
@@ -143,7 +143,8 @@ scripts.start = function(args) {
 	}
 	
 	if (flags.build !== undefined && fs.existsSync(containerFolder)) {
-		const dirs = fs.readdirSync(containerFolder);
+		const isDirectory = source => fs.lstatSync(containerFolder + '/' + source).isDirectory()
+		const dirs = fs.readdirSync(containerFolder).filter(isDirectory);
 		dirs.forEach(function(val, i) {
 			exec(`sv build --app=${applicationName} --name=${val}`);
 		});


### PR DESCRIPTION
This fixes a minor issue on MacOS where .DS_Store files were mistaken for a
build folder.