### PR TITLE
[AUT-19] upgrade helm to 2.13.1

### DIFF
--- a/scripts/install_helm.sh
+++ b/scripts/install_helm.sh
@@ -1,14 +1,14 @@
 . /sv/scripts/errorHandler.sh
 
 helm_version=$(helm version --client --short 2> /dev/null || true)
-helm_version_expected="Client: v2.10.0+g9ad53aa"
+helm_version_expected="Client: v2.13.1+618447c"
 
 if [ "$helm_version" != "$helm_version_expected" ]; then
 	apt-get update
 	apt-get install -y curl
 
 	cd /tmp
-	curl -Lo helm.tar.gz https://storage.googleapis.com/kubernetes-helm/helm-v2.10.0-linux-amd64.tar.gz
+	curl -Lo helm.tar.gz https://storage.googleapis.com/kubernetes-helm/helm-v2.13.1-linux-amd64.tar.gz
 	tar -zxvf helm.tar.gz
 	rm helm.tar.gz
 	mv linux-amd64/helm /usr/bin/helm


### PR DESCRIPTION
Related to : https://jira.simpleviewtools.com/browse/AUT-19

This PR upgrades helm to v2.13.1
Please note after upgrading helm, you will have to run helm init in the local environment. 
This PR also depends on https://github.com/simpleviewinc/sv-deploy-gce/pull/2