### PR TITLE
[DOP-32] Update to sv build to allow tagging without pushing

### DIFF
--- a/docs/sv_build.md
+++ b/docs/sv_build.md
@@ -8,7 +8,8 @@ Will result in a local docker image being tagged [container]:local
 
 * `--app` - If building an application's container, specify the name of the app.
 * `--name` - The name of the container.
-* `--pushTag` - If passed it will append this tag and attempt a docker push on that tag.
+* `--tag` - If passed it will use this tag (defaults to ${containerName:local}).
+* `--push` - If passed attempt a docker push.
 * `--build-arg` - If passed the build-arg will be passed to the Dockerfile. Pass multiple times for multiple values.
 
 Example:

--- a/sv/sv.js
+++ b/sv/sv.js
@@ -73,7 +73,8 @@ scripts.build = function(args) {
 	const flags = commandLineArgs([
 		{ name : "name", type : String },
 		{ name : "app", type : String },
-		{ name : "pushTag", type : String },
+		{ name : "tag", type : String },
+		{ name : "push", type : Boolean },
 		{ name : "build-arg", type : String, multiple: true }
 	], { argv : args.argv });
 	
@@ -95,10 +96,10 @@ scripts.build = function(args) {
 	validatePath(path);
 	
 	const commandArgs = [];
-	commandArgs.push(`-t ${containerName}:local`);
-	
-	if (flags.pushTag !== undefined) {
-		commandArgs.push(`-t ${flags.pushTag}`);
+	if (flags.tag == undefined) {
+		commandArgs.push(`-t ${containerName}:local`);
+	} else {
+		commandArgs.push(`-t ${flags.tag}`);
 	}
 	
 	if (flags["build-arg"] !== undefined) {
@@ -108,8 +109,8 @@ scripts.build = function(args) {
 	const commandArgString = commandArgs.join(" ");
 	exec(`cd ${path} && docker build ${commandArgString} .`);
 	
-	if (flags.pushTag !== undefined) {
-		exec(`cd ${path} && docker push ${flags.pushTag}`);
+	if (flags.push !== undefined) {
+		exec(`cd ${path} && docker push ${flags.tag}`);
 	}
 }
 
@@ -300,10 +301,14 @@ scripts.start = function(args) {
 		
 		dirs.forEach(function(val, i) {
 			const myBuildArgs = [...buildArgs];
+			const containerTag = `${applicationName}-${val}:${tag}`
 			myBuildArgs.push(`--name ${val}`);
 			
 			if (flags.push === true) {
-				myBuildArgs.push(`--pushTag=${dockerBase}/${applicationName}-${val}:${tag}`);
+				myBuildArgs.push(`--push`);
+				myBuildArgs.push(`--tag ${dockerBase}/${containerTag}`);
+			} else {
+				myBuildArgs.push(`--tag ${containerTag}`);
 			}
 			
 			const buildArgString = myBuildArgs.join(" ");


### PR DESCRIPTION
WARNING:  This may introduce breaking changes as it removes the `--pushTag` option from `sv build`.  Emboldened by Owen's comments on my last PR, I've made changes that I hope are inline with the spirit of the `sv` utility.  I replaced `--pushTag` with the boolean `--push` and a `--tag` option that may be used independently.  I updated `sv start` to work as expected, but never having used the push functionality it seems prudent to at least request additional scrutiny.

These changes seem necessary to get the oncethere app built and running the "dev" env locally, but I may be overlooking something which is why I've asked Ryan to look at this too.  Here's how these changes work for sv-oncethere:

```sudo sv start sv-oncethere dev --build```

Here's the error I was getting when k8s was trying to start a container from an image tag that did not exist:

```
Error from server (BadRequest): container "rms-rails" in pod "sv-oncethere-rms-rails-785f7855b8-w5bmc" is waiting to start: image can't be pulled
```