### PR TITLE
Adding fix

### DIFF
--- a/sv/sv.js
+++ b/sv/sv.js
@@ -564,7 +564,7 @@ const getCurrentPods = function(filter) {
 	// simplify the return for downstream functions
 	pods = pods.map(val => ({
 		name : val.metadata.name,
-		testCommand : val.metadata.annotations["sv-test-command"],
+		testCommand : val.metadata.annotations !== undefined && val.metadata.annotations["sv-test-command"] ? val.metadata.annotations["sv-test-command"] : undefined,
 		rootName : val.metadata.name.replace(/-[^\-]+-[^\-]+$/, ""),
 		ip : val.podIP
 	}));


### PR DESCRIPTION
Adding fix, could not use enterPod, or execPod if there was no metadata.annotation (which we use for the test command) None of the pods on sv-auth have this "annotation" except for graph. This checks for it and if its not there sets it to undefined.