### PR TITLE
Update minikube start/stop scripts to enable/disable kubelet.service

### DIFF
--- a/scripts/start_minikube.sh
+++ b/scripts/start_minikube.sh
@@ -36,4 +36,6 @@ if [ "$minikube_start" == "true" ]; then
 	. /sv/scripts/start_helm.sh
 	# adds coredns so that external dns entries finish quickly
 	kubectl apply -f /sv/internal/coredns_config.yaml
+
+	systemctl enable kubelet.service
 fi

--- a/scripts/stop_minikube.sh
+++ b/scripts/stop_minikube.sh
@@ -1,3 +1,5 @@
 minikube delete
 rm -rf /etc/kubernetes/addons
 rm -rf /root/.minikube
+
+systemctl disable kubelet.service


### PR DESCRIPTION
Whenever I restart my computer and `vagrant up`, minikube is not running.  This addition to the start/stop scripts corrects the behavior for me.

Steps to repeat issue:
1. Set up vagrant normally:
```
cd sv-kubernetes
vagrant up
vagrant ssh
sudo bash /sv/setup.sh
exit
```
2. Halt vagrant (or reboot computer)
```
vagrant halt
vagrant up
vagrant ssh
sudo kubectl get all
```
3. Observe error stating kubectl could not connect

This PR allows vagrant to start up with minikube intact removing a minor irritant from my day.
