### PR TITLE
Update sv build to build sv info (sv.json) by default

### DIFF
--- a/sv/sv.js
+++ b/sv/sv.js
@@ -90,7 +90,7 @@ scripts.build = function(args) {
 		{ name : "app", type : String },
 		{ name : "pushTag", type : String },
 		{ name : "build-arg", type : String, multiple: true },
-		{ name : "skipBuildSvInfo", type : Boolean }
+		{ name : "buildSvInfo", type : String, defaultValue : "true" }
 	], { argv : args.argv });
 	
 	if (flags.name === undefined) {
@@ -136,7 +136,7 @@ scripts.build = function(args) {
 		exec(`cd ${path} && docker push ${flags.pushTag}`);
 	}
 
-	if (flags.skipBuildSvInfo === undefined) {
+	if (flags.buildSvInfo === "true") {
 		exec(`sv _buildSvInfo`);
 	}
 }
@@ -351,7 +351,7 @@ scripts.start = function(args) {
 			
 			const buildArgString = myBuildArgs.join(" ");
 			
-			exec(`sv build --skipBuildSvInfo ${buildArgString}`);
+			exec(`sv build --buildSvInfo=false ${buildArgString}`);
 		});
 		
 		exec(`sv _buildSvInfo`);


### PR DESCRIPTION
Due to the large number and size of containers jrs-bookdirect currently requires it is often more efficient to build just the one container we're working on and then call start with the --build flag.  Even when all images are already built, the COPY commands can take a long time:
`sudo sv start jrs-bookdirect local --build` (2m 31s)

So, I typically build one container only and then use restartPod (not ideal):
`sudo sv build --app jrs-bookdirect --name bookdirect-php` (15s)
`sudo sv restartPod bookdirect-php` (0s)

I finally realized that start wasn't picking up the manually build image because sv.json isn't updated by sv build, so I tried the following and it worked:
```
sudo sv build --app jrs-bookdirect --name bookdirect-php
sudo sv _buildSvInfo
sudo sv start jrs-bookdirect local
```

Since _buildSvInfo is a "private" method within sv.js, I submit this PR to have `_buildSvInfo` called once at the conclusion of either an `sv build` or `sv start`. The following is my new workflow, which I think you'll agree is more in line with how we should be using these tools.
```
sudo sv build --app jrs-bookdirect --name bookdirect-php
sudo sv start jrs-bookdirect local
```

Once again this may be a special case to Book Direct, but I think this is an improvement which supports a reasonable expectation that an image produced by a manual `build` should be picked up by a subsequent `start` without the `--build` flag. 
