### PR TITLE
Build args support from helm values

### DIFF
--- a/sv/sv.js
+++ b/sv/sv.js
@@ -324,6 +324,17 @@ scripts.start = function(args) {
 			`--app ${applicationName}`,
 			`--build-arg SV_ENV=${env}`
 		];
+
+		// Build Args from helm values
+		try {
+			const valuesYaml = js_yaml.load(fs.readFileSync(`${envFile}`, 'utf8'));
+			if(valuesYaml["build_args"] !== undefined && valuesYaml["build_args"].length > 0) {
+				buildArgs.push(...mapBuildArgs(valuesYaml["build_args"]));
+			}
+		} catch (e) {
+			console.log(e);
+		}
+		
 		
 		if (flags["build-arg"] !== undefined) {
 			buildArgs.push(...mapBuildArgs(flags["build-arg"]));
@@ -345,6 +356,8 @@ scripts.start = function(args) {
 			}
 			
 			const buildArgString = myBuildArgs.join(" ");
+
+			console.log("Command: sv build ", buildArgString)
 			
 			exec(`sv build ${buildArgString}`);
 		});


### PR DESCRIPTION
This change implements the support to manage the build-args values from the values-<env>.yaml using this format:

`build-args:
 - "ARG_KEY1=ARG_VALUE1"
 - "ARG_KEY2=ARG_VALUE2"`