### PR TITLE
Update setup.sh

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -21,7 +21,7 @@ bash /sv/scripts/extend_disk.sh
 . /sv/scripts/start_minikube.sh
 . /sv/scripts/start_helm.sh
 
-gcloud auth application-default login
+gcloud auth application-default login --no-browser
 
 # build server config
 sv _buildSvInfo


### PR DESCRIPTION
Added the flag "--no-browser" for gcloud auth, according to new sdk version 383.