### PR TITLE
Add mac and linux support for Vagrant memory allocation

### DIFF
--- a/vagrantfile
+++ b/vagrantfile
@@ -4,10 +4,8 @@ Vagrant.configure("2") do |config|
 	config.vm.network :private_network, ip: "192.168.50.100"
 	config.vm.synced_folder ".", "/sv", owner: "root", group: "root", mount_options:["fmode=777,dmode=777"]
 	config.vm.provider "virtualbox" do |v|
-		# Sets the memory to either 4096 or total mem / 4, whichever is larger
-		mem_min = 4096
-		mem_ratio = 0.25
-		mem = [(`wmic OS get TotalVisibleMemorySize`.split("\n")[2].to_i / 1024 * mem_ratio).round, mem_min].max
+		# Sets the memory to either 4096MiB or total mem / 4, whichever is larger
+		mem = get_memory(4096, 0.25)
 		v.cpus = 2
 		v.customize ["modifyvm", :id, "--audio", "none"]
 		v.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]
@@ -36,3 +34,18 @@ Vagrant.configure("2") do |config|
 
 	config.vm.provision "file", source: "~/.ssh/github_key", destination: "/home/vagrant/.ssh/github_key"
 end
+
+# Determines amount of memory to allocate to Vagrant box, in mebibytes (MiB)
+def get_memory(mem_min, mem_ratio)
+	total_mem = nil
+	if Vagrant::Util::Platform.windows?
+		total_mem = `wmic OS get TotalVisibleMemorySize`.split("\n")[2].to_i / 1024
+	elsif Vagrant::Util::Platform.darwin? # mac
+		total_mem = `sysctl -n hw.memsize`.strip().to_i / ( 1024 * 1024 )
+	else # linux
+		total_mem = `awk '/MemTotal/ {print $2}' /proc/meminfo`.strip().to_i / 1024
+	end
+
+	[ (total_mem * mem_ratio).round, mem_min ].max
+end
+


### PR DESCRIPTION
## Context
* This fixes issue #60

## Updates
* Split out memory size retrieval to another function
* Added support for macOS and linux

## Testing
* I tested this on my own Macbook Pro. You can see from this image that it correctly set the memory to 1/4 of my total memory (32GB), about 8GB
![image](https://user-images.githubusercontent.com/9517356/190730088-624760f2-2919-47fb-8fc3-844093ae2a37.png)
* However, I don't have a Windows machine, so I need someone else to verify this doesn't break on Windows
* Furthermore, I don't have a linux machine either, but I added support for it anyway since I was here. I ran the linux command to get total memory in a linux-based docker container and verified that it returned the total in kb, but technically I can't test the full `vagrant up` on an actual linux machine. I doubt we have any devs who use linux, though.