### PR TITLE
AUT-2206: Address errors while running SV Kube on Apple Silicon

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,43 +78,8 @@ your local folder rather than within the VM.
 
 #### Troubleshooting
 
-##### Vagrant Backing Image
-
-The way we are able to build a Vagrant box for ARM64 is using a backing image
-setting which needs to be present in the `boxes` directory to be able to run our
-custom image.
-
-Run `vagrant up base` and `vagrant up` to download both boxes.
-
-Run `vagrant destroy` to clean up.
-
-Run the command below to make sure the path is aligned with current user.
-
-```bash
-qemu-img rebase -u -F qcow2 -b ~/.vagrant.d/boxes/perk-VAGRANTSLASH-ubuntu-2204-arm64/20230712/arm64/libvirt/box.img ~/.vagrant.d/boxes/owenallenaz-VAGRANTSLASH-sv-kubernetes/0.0.7/arm64/libvirt/box.img
-```
-
-##### Port Already in Use
-
-While running `vagrant up`, if you come across a port already in use error, it
-could mean that there is still a QEMU process running in the background. Run the
-following command to clear the QEMU processes.
-
-```bash
-killall qemu-system-aarch64
-```
-
-##### SMB Mount Error Permission Denied
-
-If you see this error, make sure you've restarted your MacBook after enabling
-SMB share folders.
-
-##### Missing Containers Dependencies
-
-In case you're trying to run a project that has containers dependencies, you
-need to manually clone them into the `containers/` folder before starting your
-app.
-
+For common errors that can occur running SV Kubernetes on an ARM system, see the
+[General Troubleshooting] section in Confluence.
 
 ## Installation
 
@@ -466,3 +431,4 @@ sudo APPS_FOLDER=/sv/sv/testing/applications sv editSecrets settings-test --env 
 
 [Environment Setup instructions]: https://simpleviewtools.atlassian.net/wiki/spaces/ENG/pages/32079956/Environment+Setup
 [setup SMB on MacOS]: https://developer.hashicorp.com/vagrant/docs/synced-folders/smb#macos-host
+[General Troubleshooting]: https://simpleviewtools.atlassian.net/wiki/spaces/ENG/pages/32080165/SV-Kubernetes

--- a/vagrantfile
+++ b/vagrantfile
@@ -61,7 +61,6 @@ Vagrant.configure("2") do |config|
 			c.vm.provider "qemu" do |v|
 				v.memory = mem
 				v.smp = 2
-				#v.extra_netdev_args = "net=192.168.50.96/29,dhcpstart=192.168.50.100"
 				v.ssh_port = 2223
 			end
 		end


### PR DESCRIPTION
See errors detail in ticket [AUT-2206](https://simpleviewtools.atlassian.net/browse/AUT-2206)

* Error 1 & 2: Could not open backing image
  * Added extra commands to run in `readme.md` to avoid image errors
* Error 3: APT already in use
  * Rare case where the provisioning script tries to install Ubuntu packages while Ubuntu is already running some installation. Re-run `vagrant up` after a few minutes
* Error 4: Port already in use
  * Added extra command in `readme.md` to clean QEMU processes that might be running in the background
* Error 5: mount error(13): Permission denied
  * This error occurred after enabling/configuring SMB shared folders but without rebooting the system. Reboot before running `vagrant up`
* Error 6 & 7: fdisk: cannot open /dev/sda: No such file or directory
  * This error only appeared on QA MacBook. I prevented the extend disk script from running with QEMU as it would not work anyways

To solve the error about `sv-geo-client` missing container, simply clone the repo manually as we are not using `sv install` command in that scenario.

```bash
git clone git@github.com:simpleviewinc/sv-geo-client.git containers/sv-geo-client 
```

I also removed the DHCP config of QEMU provider as that was preventing accessing the GraphQL UI from the MacBook 

[AUT-2206]: https://simpleviewtools.atlassian.net/browse/AUT-2206?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ