### PR TITLE
Updates for cms-reactor

### DIFF
--- a/sv/constants.js
+++ b/sv/constants.js
@@ -2,7 +2,7 @@ const fs = require("fs");
 
 /** Folder path where applications are found. */
 module.exports.APPS_FOLDER = process.env.APPS_FOLDER || "/sv/applications";
-module.exports.CONTAINERS_FOLDER = "/sv/containers";
+module.exports.CONTAINERS_FOLDER = process.env.CONTAINERS_FOLDER || "/sv/containers";
 module.exports.GRAPH_URL = "https://graphql.simpleviewinc.com";
 module.exports.REFRESH_TOKEN_PATH = "/sv/internal/refresh_token";
 module.exports.AUTH_TOKEN_PATH = "/sv/internal/auth_token";

--- a/sv/scripts.js
+++ b/sv/scripts.js
@@ -30,6 +30,8 @@ function build({ argv }) {
 		{ name : "app", type : String },
 		{ name : "pushTag", type : String },
 		{ name : "env", type : String },
+		{ name : "imageName", type : String },
+		{ name : "secret", type : String, multiple: true },
 		{ name : "build-arg", type : String, multiple: true }
 	], { argv });
 
@@ -53,10 +55,20 @@ function build({ argv }) {
 	validatePath(path);
 
 	const commandArgs = [];
-	commandArgs.push(`-t ${containerName}:local`);
+
+	// Use imageName local tag if provided, otherwise use default local tag
+	if (flags.imageName !== undefined) {
+		commandArgs.push(`-t ${flags.imageName}:local`);
+	} else {
+		commandArgs.push(`-t ${containerName}:local`);
+	}
 
 	if (flags.pushTag !== undefined) {
 		commandArgs.push(`-t ${flags.pushTag}`);
+	}
+
+	if (flags.secret !== undefined) {
+		commandArgs.push(`--secret ${flags.secret}`);
 	}
 
 	if (flags.pushTag !== undefined) {
@@ -116,12 +128,14 @@ function build({ argv }) {
 
 	const commandArgString = commandArgs.join(" ");
 
-	log(`Starting build of ${containerName}`);
+	// Use the appropriate name for logging
+	const displayName = flags.imageName || containerName;
+	log(`Starting build of ${displayName}`);
 
 	exec(`cd ${path} && docker build ${commandArgString} .`, {
 		env: getDockerEnv()
 	});
-	log(`Completed build of ${containerName}`);
+	log(`Completed build of ${displayName}`);
 
 	if (flags.pushTag !== undefined) {
 		exec(`cd ${path} && docker push ${flags.pushTag}`);


### PR DESCRIPTION
- Allows CONTAINERS_FOLDER to be defined as a process.env var
- Adds `imageName` to build cmd so multiple, unique, client-specific images can be created.
- Adds `secret` to build cmd to take advantage of Docker build secrets (https://docs.docker.com/build/building/secrets/)

Here is the cms-reactor start script that makes use of these changes: https://github.com/simpleviewinc/cms-reactor/blob/client-as-container/scripts/start.js