### PR TITLE
docker images to be conditionally built from values_/secrets files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -140,6 +140,10 @@ interface BuildArgContainer {
 	 * Array of arguments to pass to the container
 	 */
 	args: BuildArg[]
+	/**
+	 * Whether or not to build the container. This can be a calculated value from secrets or env vars like a BuildArg.path
+	 */
+	build?: boolean
 }
 
 interface BuildArg {

--- a/sv/definitions.d.ts
+++ b/sv/definitions.d.ts
@@ -103,6 +103,10 @@ interface BuildArgContainer {
 	 * Array of arguments to pass to the container
 	 */
 	args: BuildArg[]
+	/**
+	 * Whether or not to build the container. This can be a calculated value from secrets or env vars like a BuildArg.path
+	 */
+	build?: boolean
 }
 
 interface BuildArg {

--- a/sv/scripts.js
+++ b/sv/scripts.js
@@ -96,6 +96,11 @@ function build({ argv }) {
 		const envValues = loadYaml(`${appPath}/chart/values_${flags.env}.yaml`);
 		mergeData.values = deepMerge(rootValues, envValues);
 
+		const buildContainer = containerBuildArgs.build !== undefined ? lodash.get(mergeData, String(containerBuildArgs.build)) : true;
+		if (!buildContainer) {
+			return; // don't build container
+		}
+
 		for(let arg of containerBuildArgs.args) {
 			const value = lodash.get(mergeData, arg.path);
 

--- a/sv/scripts.js
+++ b/sv/scripts.js
@@ -98,6 +98,7 @@ function build({ argv }) {
 
 		const buildContainer = containerBuildArgs.build !== undefined ? lodash.get(mergeData, String(containerBuildArgs.build)) : true;
 		if (!buildContainer) {
+			console.warn(`WARN: Build of ${containerName} skipped by build argument`);
 			return; // don't build container
 		}
 


### PR DESCRIPTION
Adds a buildArg param called `build` which takes a computed value or a secret to enable/disable the building of the docker image. I'm not sold on the name of the argument but this should save a bit of time especially when building an app with many containers, several of which are conditionally used based on values_ files such as `cms-reactor` (eg: foundation, cms-component-library).