### PR TITLE
CMS-324440 Distro Pin

### DIFF
--- a/install_windows.md
+++ b/install_windows.md
@@ -2,8 +2,6 @@
 
 Running sv-kubernetes via the WSL requires the following features and systems:
 
-* WSL v2 - See intructions below for installation.
-* Docker Engine - See instructions below for installation.
 * Ability to run CMD prompt as Admin and install software as Admin.
 * Git installed and accessible in command prompt
 
@@ -43,8 +41,8 @@ You need to configure the WSL on your machine.
         * Once downloaded, run the file.
         * After complete, re-run command prompt and run `wsl --version` and ensure it's been updated.
     * Run `wsl --install --no-distribution`. You may be prompted to reboot, if so reboot and then continue after the reboot.
-    * Run `wsl --install Ubuntu`
-    * Run `wsl --set-default Ubuntu`.
+    * Run `wsl --install Ubuntu-24.04`
+    * Run `wsl --set-default Ubuntu-24.04`.
     * Run `wsl`. It should boot the instance and enter into an Ubuntu console.
     * Run `exit`.
 
@@ -98,7 +96,7 @@ If you want to reset your WSL distribution, run the following commands.
 
 * `wsl --list` - determine the current installation that you want to reset. Do not reset your docker-desktop instance.
 * `wsl --unregister InstallationName`
-* `wsl --install Ubuntu`
-* `wsl --set-default Ubuntu`
+* `wsl --install Ubuntu-24.04`
+* `wsl --set-default Ubuntu-24.04`
 * `wsl`, ensure no errors on entry, `exit`.
 * Proceed to the Setup WSL Instance section.

--- a/install_windows.md
+++ b/install_windows.md
@@ -41,8 +41,8 @@ You need to configure the WSL on your machine.
         * Once downloaded, run the file.
         * After complete, re-run command prompt and run `wsl --version` and ensure it's been updated.
     * Run `wsl --install --no-distribution`. You may be prompted to reboot, if so reboot and then continue after the reboot.
-    * Run `wsl --install Ubuntu-24.04`
-    * Run `wsl --set-default Ubuntu-24.04`.
+    * Run `wsl --install Ubuntu-24.04 --name Ubuntu`
+    * Run `wsl --set-default Ubuntu`.
     * Run `wsl`. It should boot the instance and enter into an Ubuntu console.
     * Run `exit`.
 
@@ -96,7 +96,7 @@ If you want to reset your WSL distribution, run the following commands.
 
 * `wsl --list` - determine the current installation that you want to reset. Do not reset your docker-desktop instance.
 * `wsl --unregister InstallationName`
-* `wsl --install Ubuntu-24.04`
-* `wsl --set-default Ubuntu-24.04`
+* `wsl --install Ubuntu-24.04 --name Ubuntu`
+* `wsl --set-default Ubuntu`
 * `wsl`, ensure no errors on entry, `exit`.
 * Proceed to the Setup WSL Instance section.

--- a/scripts/windows_init.ps1
+++ b/scripts/windows_init.ps1
@@ -53,7 +53,6 @@ netsh interface ipv4 add address "Loopback Pseudo-Interface 1" 192.168.50.100 25
 echo "Copying .cloud-init config"
 New-Item -ItemType Directory -Force -Path $Env:UserProfile\.cloud-init | Out-Null
 copy $PSScriptRoot\..\internal\Ubuntu.user-data $Env:UserProfile\.cloud-init\Ubuntu.user-data
-copy $PSScriptRoot\..\internal\Ubuntu.user-data $Env:UserProfile\.cloud-init\Ubuntu-24.04.user-data
 
 Write-Output "Copying user profile script"
 $psProfileDir = "$Env:UserProfile\Documents\WindowsPowerShell"

--- a/scripts/windows_init.ps1
+++ b/scripts/windows_init.ps1
@@ -53,6 +53,7 @@ netsh interface ipv4 add address "Loopback Pseudo-Interface 1" 192.168.50.100 25
 echo "Copying .cloud-init config"
 New-Item -ItemType Directory -Force -Path $Env:UserProfile\.cloud-init | Out-Null
 copy $PSScriptRoot\..\internal\Ubuntu.user-data $Env:UserProfile\.cloud-init\Ubuntu.user-data
+copy $PSScriptRoot\..\internal\Ubuntu.user-data $Env:UserProfile\.cloud-init\Ubuntu-24.04.user-data
 
 Write-Output "Copying user profile script"
 $psProfileDir = "$Env:UserProfile\Documents\WindowsPowerShell"


### PR DESCRIPTION
A chain of events since this documentation was created has resulted in it being invalid:

- At the time of writing, the default Ubuntu distro was 24.04. The default distro is now 26.04
- The apt-key package has been deprecated and is therefore not bundled in Ubuntu 26.04 by default, leading to errors being thrown when gcloud is being installed.

This provides a temporary solution to these issues by pinning the Ubuntu version in the instruction guide, ensuring that the tested version will be installed. It also copies the cloud config under the corrected name during the Window initialisation phase. The original cloud config copy has been left intact.

Note I've also removed the WSL and Docker Engine prerequisites to avoid confusion. Having them here gives the implication that those installations need to be carried out first, which would lead to errors. The user should reach those parts of the instructions organically.