### PR TITLE
CMS-324441 WSL Tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ node_modules
 extended-disk.vdi
 packer.exe
 /output-sv-kubernetes
+.wsl_migrated

--- a/install_windows.md
+++ b/install_windows.md
@@ -42,7 +42,7 @@ You need to configure the WSL on your machine.
         * After complete, re-run command prompt and run `wsl --version` and ensure it's been updated.
     * Run `wsl --install --no-distribution`. You may be prompted to reboot, if so reboot and then continue after the reboot.
     * Run `wsl --install Ubuntu-24.04 --name Ubuntu`
-    * After the install finishes, you will automatically be moved into the WSL shell. Run `exit` to exit out of it.
+    * Run `exit` to exit out of the installed WSL instance.
     * Run `wsl --set-default Ubuntu`.
     * Run `wsl --shutdown`.
     * Run `wsl`. It should boot the instance and enter into an Ubuntu console. Running `whoami` should show you as `root`.

--- a/install_windows.md
+++ b/install_windows.md
@@ -36,14 +36,16 @@ You need to configure the WSL on your machine.
 1. Check that necessary features are enabled. Hit the windows key and type in `Turn Windows Features on or off`. It should bring up a UI of checkboxes.
     * Ensure that `Hyper-V`, `Virtual Machine Platform` and `Windows Subsystem for Linux` are checked. If they are not checked, check them, they will install and your machine will reboot.
 3. In CMD prompt as Admin:
-    * Run `wsl --version` you should be on at least `WSL version: 2.4.13.0`. If your version is older, you will need to update your wsl version. If you are on a newer version it likely will work ok, but it hasn't been officially tested. If the command `wsl --version` fails with an error saying that `wsl --version` doesn't exist, then you should update.
+    * Run `wsl --version` you should be on at least `WSL version: 2.4.13.0`. If your version is older, you will need to update your wsl version. If you are on a newer version it likely will work ok. This has been tested up to version `2.7.3.0`. If the command `wsl --version` fails with an error saying that `wsl --version` doesn't exist, then you should update.
         * Download the proper version of wsl by clicking the following link: [Download WSL](https://github.com/microsoft/WSL/releases/download/2.4.13/wsl.2.4.13.0.x64.msi)
         * Once downloaded, run the file.
         * After complete, re-run command prompt and run `wsl --version` and ensure it's been updated.
     * Run `wsl --install --no-distribution`. You may be prompted to reboot, if so reboot and then continue after the reboot.
     * Run `wsl --install Ubuntu-24.04 --name Ubuntu`
+    * After the install finishes, you will automatically be moved into the WSL shell. Run `exit` to exit out of it.
     * Run `wsl --set-default Ubuntu`.
-    * Run `wsl`. It should boot the instance and enter into an Ubuntu console.
+    * Run `wsl --shutdown`.
+    * Run `wsl`. It should boot the instance and enter into an Ubuntu console. Running `whoami` should show you as `root`.
     * Run `exit`.
 
 ## Install Docker Engine

--- a/internal/Ubuntu.user-data
+++ b/internal/Ubuntu.user-data
@@ -10,5 +10,15 @@ write_files:
     content: |
       [boot]
       systemd=false
+      command=bash -c '\
+        mkdir -p /mnt/wsl/sv-kubernetes && \
+        mount --bind /home/vagrant/sv-kubernetes /mnt/wsl/sv-kubernetes \
+        cat >> /root/.profile <<'EOF' \
+        \
+        export APPS_FOLDER="/sv-wsl/applications" \
+        export CONTAINERS_FOLDER="/sv-wsl/containers" \
+        \
+        EOF \
+      '
       [user]
-      default=vagrant
+      default=root

--- a/internal/Ubuntu.user-data
+++ b/internal/Ubuntu.user-data
@@ -12,7 +12,7 @@ write_files:
       systemd=false
       command=bash -c '\
         mkdir -p /mnt/wsl/sv-kubernetes && \
-        mount --bind /home/vagrant/sv-kubernetes /mnt/wsl/sv-kubernetes \
+        mount --bind /root/sv-kubernetes /mnt/wsl/sv-kubernetes \
       '
       [user]
       default=root

--- a/internal/Ubuntu.user-data
+++ b/internal/Ubuntu.user-data
@@ -13,12 +13,6 @@ write_files:
       command=bash -c '\
         mkdir -p /mnt/wsl/sv-kubernetes && \
         mount --bind /home/vagrant/sv-kubernetes /mnt/wsl/sv-kubernetes \
-        cat >> /root/.profile <<'EOF' \
-        \
-        export APPS_FOLDER="/sv-wsl/applications" \
-        export CONTAINERS_FOLDER="/sv-wsl/containers" \
-        \
-        EOF \
       '
       [user]
       default=root

--- a/internal/Ubuntu.user-data.old
+++ b/internal/Ubuntu.user-data.old
@@ -1,0 +1,14 @@
+#cloud-config
+users:
+  - name: vagrant
+    groups: [adm,cdrom,sudo,dip,plugdev,users]
+    sudo: ALL=(ALL) NOPASSWD:ALL
+    shell: /bin/bash
+
+write_files:
+  - path: /etc/wsl.conf
+    content: |
+      [boot]
+      systemd=false
+      [user]
+      default=vagrant

--- a/migrate_into_wsl.md
+++ b/migrate_into_wsl.md
@@ -20,9 +20,13 @@ The `sv` tool runs inside **WSL** (a Linux environment on your PC). When your re
 
 ## Before you start the migration
 
-1. Confirm WSL works: open Command Prompt and run `wsl -u root`. You should get a Linux prompt. Type `exit` to leave.
-2. Close any editors or terminals that have files open under `C:\sv-kubernetes\applications` or `C:\sv-kubernetes\containers`.
-3. Allow plenty of time if you have many repos—the copy step can run for **hours**.
+1. Confirm WSL works: open Command Prompt and run `wsl -u root`. You should get a Linux prompt.
+2. Stop all of your applications.
+   - `helm list` to show running applications
+   - `sv stop [application]` to stop each application
+4. Type `exit` to leave.
+5. Close any editors or terminals that have files open under `C:\sv-kubernetes\applications` or `C:\sv-kubernetes\containers`.
+6. Allow plenty of time if you have many repos—the copy step can run for **hours**.
 
 ## How to run the migration
 

--- a/migrate_into_wsl.md
+++ b/migrate_into_wsl.md
@@ -31,31 +31,32 @@ The `sv` tool runs inside **WSL** (a Linux environment on your PC). When your re
 ## How to run the migration
 
 1. Pull the latest `sv-kubernetes` changes on the master branch.
-2. Open **Command Prompt**.
-3. Enter WSL as root:
+2. Open a **Powershell** terminal (it doesn't need to have elevated privileges).
+3. Run `copy C:\sv-kubernetes\internal\Ubuntu.user-data $Env:UserProfile\.cloud-init\Ubuntu.user-data`
+4. Enter WSL as root:
 
    ```bash
    wsl -u root
    ```
 
-4. Run the migration script:
+5. Run the migration script:
 
    ```bash
    bash /sv/scripts/migrate_wsl.sh
    ```
 
-5. The script updates your settings so `sv` knows to use the new locations.
+6. The script updates your settings so `sv` knows to use the new locations.
 
-6. If you already have repos under `C:\sv-kubernetes\applications` or `C:\sv-kubernetes\containers`, the script will ask whether to **copy** them into WSL. See the next section. The script can copy everything from the old folders into WSL for you. **Allowing the migration script to do this automatically can take a _really_ long time**. A few small repos might finish in minutes. Many repos - or large ones with lots of files (particularly node_modules) - can take **hours**.
+7. If you already have repos under `C:\sv-kubernetes\applications` or `C:\sv-kubernetes\containers`, the script will ask whether to **copy** them into WSL. See the next section. The script can copy everything from the old folders into WSL for you. **Allowing the migration script to do this automatically can take a _really_ long time**. A few small repos might finish in minutes. Many repos - or large ones with lots of files (particularly node_modules) - can take **hours**.
 
    When you see the text `Would you like to copy automatically? (y/n)`
 
    - Press **`y`** to copy your repos automatically.
    - Press **`n`** to skip copying. Your settings will still be updated, but you will need to put repos in the new place yourself—e.g. run `sv install` again for each project, or copy the folders manually.
 
-7. Run `exit` to exit the WSL shell.
-8. Run `wsl --shutdown` to shutdown WSL.
-9. Run `wsl` (the `-u root` flag is no longer necessary.)
+8. Run `exit` to exit the WSL shell.
+9. Run `wsl --shutdown` to shutdown WSL.
+10. Run `wsl` (the `-u root` flag is no longer necessary.)
 
 ## After migration: where to find your repos
 

--- a/migrate_into_wsl.md
+++ b/migrate_into_wsl.md
@@ -50,7 +50,7 @@ The `sv` tool runs inside **WSL** (a Linux environment on your PC). When your re
 
 ## Copying your repos
 
-The script can copy everything from the old folders into WSL for you. **Allowing the migration script to do this automatically can take a _really_ long time**. A few small repos might finish in minutes. Many repos—or large ones with lots of files—can take **hours**. The script shows progress while it runs.
+The script can copy everything from the old folders into WSL for you. **Allowing the migration script to do this automatically can take a _really_ long time**. A few small repos might finish in minutes. Many repos - or large ones with lots of files (particularly node_modules) - can take **hours**. The script shows progress while it runs.
 
 When you see:
 

--- a/migrate_into_wsl.md
+++ b/migrate_into_wsl.md
@@ -26,26 +26,27 @@ The `sv` tool runs inside **WSL** (a Linux environment on your PC). When your re
    - `sv stop [application]` to stop each application
 4. Type `exit` to leave.
 5. Close any editors or terminals that have files open under `C:\sv-kubernetes\applications` or `C:\sv-kubernetes\containers`.
-6. Allow plenty of time if you have many repos—the copy step can run for **hours**.
+6. If you plan to let the migration script automatically copy your repos, allow plenty of time; the copy step can run for **hours**.
 
 ## How to run the migration
 
-1. Open **Command Prompt**.
-2. Enter WSL as root:
+1. Pull the latest `sv-kubernetes` changes on the master branch.
+2. Open **Command Prompt**.
+3. Enter WSL as root:
 
    ```bash
    wsl -u root
    ```
 
-3. Run the migration script:
+4. Run the migration script:
 
    ```bash
    bash /sv/scripts/migrate_wsl.sh
    ```
 
-4. The script updates your settings so `sv` knows to use the new locations.
+5. The script updates your settings so `sv` knows to use the new locations.
 
-5. If you already have repos under `C:\sv-kubernetes\applications` or `C:\sv-kubernetes\containers`, the script will ask whether to **copy** them into WSL. See the next section.
+6. If you already have repos under `C:\sv-kubernetes\applications` or `C:\sv-kubernetes\containers`, the script will ask whether to **copy** them into WSL. See the next section.
 
 ## Copying your repos
 

--- a/migrate_into_wsl.md
+++ b/migrate_into_wsl.md
@@ -2,18 +2,18 @@
 
 ## What is this about?
 
-On Windows, your **application** and **container** repos (the code you install with `sv install`) may live here:
+On Windows, your application and container repos (the code you install with `sv install`) may live here:
 
 - `C:\sv-kubernetes\applications`
 - `C:\sv-kubernetes\containers`
 
-The `sv` tool runs inside **WSL** (a Linux environment on your PC). When your repos stay on the `C:` drive, Windows and WSL pass files back and forth constantly. That is slower and can cause problems when building or starting apps.
+The `sv` tool runs inside WSL (a Linux environment on your PC). When your repos stay on the `C:` drive, Windows and WSL pass files back and forth constantly. That is slower and can cause problems when building or starting apps.
 
-**Migrating** means copying those repos into WSL’s own storage so everything lives in one place. After that, `sv` looks for your projects there instead of under `C:\sv-kubernetes\applications` and `C:\sv-kubernetes\containers`.
+Migrating means copying those repos into WSL’s own storage so everything lives in one place. After that, `sv` looks for your projects there instead of under `C:\sv-kubernetes\applications` and `C:\sv-kubernetes\containers`.
 
 ## Do I have to do this?
 
-**No.** You can keep using the `C:\sv-kubernetes\applications` and `C:\sv-kubernetes\containers` folders if everything works for you today. There is no deadline to migrate at this time.
+No. You can keep using the `C:\sv-kubernetes\applications` and `C:\sv-kubernetes\containers` folders if everything works for you today. There is no deadline to migrate at this time.
 
 - **New installs** are set up on the WSL side automatically during [Windows installation](install_windows.md).
 - **Existing installs** can proceed with migrating whenever you want to.
@@ -31,7 +31,7 @@ The `sv` tool runs inside **WSL** (a Linux environment on your PC). When your re
 ## How to run the migration
 
 1. Pull the latest `sv-kubernetes` changes on the master branch.
-2. Open a **Powershell** terminal (it doesn't need to have elevated privileges).
+2. Open a Powershell terminal (it doesn't need to have elevated privileges).
 3. Run `copy C:\sv-kubernetes\internal\Ubuntu.user-data $Env:UserProfile\.cloud-init\Ubuntu.user-data`
 4. Enter WSL as root:
 
@@ -47,7 +47,7 @@ The `sv` tool runs inside **WSL** (a Linux environment on your PC). When your re
 
 6. The script updates your settings so `sv` knows to use the new locations.
 
-7. If you already have repos under `C:\sv-kubernetes\applications` or `C:\sv-kubernetes\containers`, the script will ask whether to **copy** them into WSL. **Allowing the migration script to do this automatically can take a _really_ long time**. A few small repos might finish in minutes. Many repos - or large ones with lots of files (particularly node_modules) - can take **hours**.
+7. If you already have repos under `C:\sv-kubernetes\applications` or `C:\sv-kubernetes\containers`, the script will ask whether to copy your repos from the Windows filesystem. Copying will honor each repo's `.gitignore`, so ignored trees (for example `node_modules`) are skipped. Expect **hours** for large, complex repos; a few small ones may finish in minutes.
 
    When you see the text `Would you like to copy automatically? (y/n)`
 
@@ -97,7 +97,7 @@ After migration, open repos from their WSL locations—not from `C:\sv-kubernete
 
 ### VS Code or Cursor
 
-You need the **WSL** extension installed in the editor (in VS Code this is “WSL”; Cursor includes equivalent remote/WSL support).
+You need the WSL extension installed in the editor (in VS Code this is “WSL”; Cursor includes equivalent remote/WSL support).
 
 **Connect to WSL**
 
@@ -144,13 +144,13 @@ Examples for a repo named `my-app`:
 - File Explorer: `\\wsl.localhost\Ubuntu\root\sv-kubernetes\applications\my-app`
 - WSL: `/root/sv-kubernetes/applications/my-app`
 
-The sv-kubernetes **install** folder stays at `C:\sv-kubernetes`. Only your **application and container** project folders move.
+The sv-kubernetes install folder stays at `C:\sv-kubernetes`. Only your application and container project folders move.
 
 ## Rollback
 
 Rolling back means undoing the migration so `sv` again uses your repos under `C:\sv-kubernetes\applications` and `C:\sv-kubernetes\containers` instead of those locations on the WSL filesystem. That is useful if something breaks, you need the old layout temporarily, or you want to fix your environment and migrate again later.
 
-1. Open a **Powershell** terminal (it doesn't need to have elevated privileges).
+1. Open a Powershell terminal (it doesn't need to have elevated privileges).
 2. Enter WSL as root:
 
    ```bash
@@ -163,7 +163,7 @@ Rolling back means undoing the migration so `sv` again uses your repos under `C:
    bash /sv/scripts/rollback_wsl.sh
    ```
 
-4. The script will ask whether to **copy** your repos from WSL. **Allowing the rollback script to do this automatically can take a _really_ long time**. A few small repos might finish in minutes. Many repos - or large ones with lots of files (particularly node_modules) - can take **hours**.
+4. The script will ask whether to copy your repos from WSL. Copying will honor each repo's `.gitignore`, so ignored trees (for example `node_modules`) are skipped. Expect **hours** for large, complex repos; a few small ones may finish in minutes.
 
    When you see the text `Would you like to copy automatically? (y/n)`
 

--- a/migrate_into_wsl.md
+++ b/migrate_into_wsl.md
@@ -24,9 +24,9 @@ The `sv` tool runs inside **WSL** (a Linux environment on your PC). When your re
 2. Stop all of your applications.
    - `helm list` to show running applications
    - `sv stop [application]` to stop each application
-4. Type `exit` to leave.
-5. Close any editors or terminals that have files open under `C:\sv-kubernetes\applications` or `C:\sv-kubernetes\containers`.
-6. If you plan to let the migration script automatically copy your repos, allow plenty of time; the copy step can run for **hours**.
+3. Type `exit` to leave.
+4. Close any editors or terminals that have files open under `C:\sv-kubernetes\applications` or `C:\sv-kubernetes\containers`.
+5. If you plan to let the migration script automatically copy your repos, allow plenty of time; the copy step can run for **hours**.
 
 ## How to run the migration
 
@@ -47,7 +47,7 @@ The `sv` tool runs inside **WSL** (a Linux environment on your PC). When your re
 
 6. The script updates your settings so `sv` knows to use the new locations.
 
-7. If you already have repos under `C:\sv-kubernetes\applications` or `C:\sv-kubernetes\containers`, the script will ask whether to **copy** them into WSL. See the next section. The script can copy everything from the old folders into WSL for you. **Allowing the migration script to do this automatically can take a _really_ long time**. A few small repos might finish in minutes. Many repos - or large ones with lots of files (particularly node_modules) - can take **hours**.
+7. If you already have repos under `C:\sv-kubernetes\applications` or `C:\sv-kubernetes\containers`, the script will ask whether to **copy** them into WSL. **Allowing the migration script to do this automatically can take a _really_ long time**. A few small repos might finish in minutes. Many repos - or large ones with lots of files (particularly node_modules) - can take **hours**.
 
    When you see the text `Would you like to copy automatically? (y/n)`
 
@@ -145,3 +145,31 @@ Examples for a repo named `my-app`:
 - WSL: `/root/sv-kubernetes/applications/my-app`
 
 The sv-kubernetes **install** folder stays at `C:\sv-kubernetes`. Only your **application and container** project folders move.
+
+## Rollback
+
+Rolling back means undoing the migration so `sv` again uses your repos under `C:\sv-kubernetes\applications` and `C:\sv-kubernetes\containers` instead of those locations on the WSL filesystem. That is useful if something breaks, you need the old layout temporarily, or you want to fix your environment and migrate again later.
+
+1. Open a **Powershell** terminal (it doesn't need to have elevated privileges).
+2. Enter WSL as root:
+
+   ```bash
+   wsl -u root
+   ```
+
+3. Run the rollback script:
+
+   ```bash
+   bash /sv/scripts/rollback_wsl.sh
+   ```
+
+4. The script will ask whether to **copy** your repos from WSL. **Allowing the rollback script to do this automatically can take a _really_ long time**. A few small repos might finish in minutes. Many repos - or large ones with lots of files (particularly node_modules) - can take **hours**.
+
+   When you see the text `Would you like to copy automatically? (y/n)`
+
+   - Press **`y`** to copy your repos automatically.
+   - Press **`n`** to skip copying. Your settings will still be updated, but you will need to put repos in the old place yourself—e.g. run `sv install` again for each project, or copy the folders manually.
+
+5. Run `exit` to exit the WSL shell.
+6. Run `wsl --shutdown` to shutdown WSL.
+7. Run `wsl -u root` (the `-u root` flag is now necessary again.)

--- a/migrate_into_wsl.md
+++ b/migrate_into_wsl.md
@@ -1,0 +1,145 @@
+# Migrate into WSL
+
+## What is this about?
+
+On Windows, your **application** and **container** repos (the code you install with `sv install`) may live here:
+
+- `C:\sv-kubernetes\applications`
+- `C:\sv-kubernetes\containers`
+
+The `sv` tool runs inside **WSL** (a Linux environment on your PC). When your repos stay on the `C:` drive, Windows and WSL pass files back and forth constantly. That is slower and can cause problems when building or starting apps.
+
+**Migrating** means copying those repos into WSL’s own storage so everything lives in one place. After that, `sv` looks for your projects there instead of under `C:\sv-kubernetes\applications` and `C:\sv-kubernetes\containers`.
+
+## Do I have to do this?
+
+**No.** You can keep using the `C:\sv-kubernetes\applications` and `C:\sv-kubernetes\containers` folders if everything works for you today. There is no deadline to migrate at this time.
+
+- **New installs** are set up on the WSL side automatically during [Windows installation](install_windows.md).
+- **Existing installs** can proceed with migrating whenever you want to.
+
+## Before you start the migration
+
+1. Confirm WSL works: open Command Prompt and run `wsl -u root`. You should get a Linux prompt. Type `exit` to leave.
+2. Close any editors or terminals that have files open under `C:\sv-kubernetes\applications` or `C:\sv-kubernetes\containers`.
+3. Allow plenty of time if you have many repos—the copy step can run for **hours**.
+
+## How to run the migration
+
+1. Open **Command Prompt**.
+2. Enter WSL as root:
+
+   ```bash
+   wsl -u root
+   ```
+
+3. Run the migration script:
+
+   ```bash
+   bash /sv/scripts/migrate_wsl.sh
+   ```
+
+4. The script updates your settings so `sv` knows to use the new locations.
+
+5. If you already have repos under `C:\sv-kubernetes\applications` or `C:\sv-kubernetes\containers`, the script will ask whether to **copy** them into WSL. See the next section.
+
+## Copying your repos
+
+The script can copy everything from the old folders into WSL for you. **Allowing the migration script to do this automatically can take a _really_ long time**. A few small repos might finish in minutes. Many repos—or large ones with lots of files—can take **hours**. The script shows progress while it runs.
+
+When you see:
+
+```text
+Would you like to copy automatically? (y/n)
+```
+
+- Press **`y`** to copy your repos automatically.
+- Press **`n`** to skip copying. Your settings will still be updated, but you will need to put repos in the new place yourself—e.g. run `sv install` again for each project, or copy the folders manually.
+
+## After migration: where to find your repos
+
+Do not open or edit projects here anymore (they are no longer used by `sv`):
+
+- `C:\sv-kubernetes\applications`
+- `C:\sv-kubernetes\containers`
+
+Use the new locations below instead.
+
+### From Windows (File Explorer)
+
+1. Open File Explorer.
+2. In the address bar, paste one of these:
+
+   ```text
+   \\wsl.localhost\Ubuntu\root\sv-kubernetes\applications
+   \\wsl.localhost\Ubuntu\root\sv-kubernetes\containers
+   ```
+
+3. Press Enter. Pin these locations in Windows Explorer if you use them often, or update existing shortcuts to these paths.
+
+### From WSL
+
+```bash
+cd /root/sv-kubernetes/applications
+```
+
+For containers:
+
+```bash
+cd /root/sv-kubernetes/containers
+```
+
+## Tooling
+
+After migration, open repos from their WSL locations—not from `C:\sv-kubernetes\applications` or `C:\sv-kubernetes\containers`.
+
+### VS Code or Cursor
+
+You need the **WSL** extension installed in the editor (in VS Code this is “WSL”; Cursor includes equivalent remote/WSL support).
+
+**Connect to WSL**
+
+1. Open the Command Palette (`Ctrl+Shift+P`).
+2. Run **“WSL: Connect to WSL”** (VS Code) or the equivalent WSL connect command in Cursor.
+3. The editor reconnects with a WSL session. The window title or status bar should indicate you are connected to WSL (often showing `WSL: Ubuntu` or similar).
+
+**Open a repo**
+
+With WSL connected:
+
+1. Open the Command Palette again.
+2. Run **“WSL: Open Folder in WSL”** (or **File → Open Folder** while connected to WSL).
+3. Navigate to your repo, for example:
+
+   ```text
+   /root/sv-kubernetes/applications/my-app
+   # or
+   /root/sv-kubernetes/containers/my-container
+   ```
+
+Alternatively, in File Explorer go to `\\wsl.localhost\Ubuntu\root\sv-kubernetes\applications\my-app`, right-click the folder, and choose **Open with Code** or **Open with Cursor** if that option is available.
+
+**Extensions inside WSL**
+
+Extensions installed only on Windows do not automatically apply to files opened in WSL. After you connect to WSL and open a folder there, check the Extensions view: many extensions show an **Install in WSL** button. Install (or reinstall) language and tooling extensions there so linting, debugging, and formatters work against your WSL repos.
+
+### Git clients with a UI (e.g. TortoiseGit)
+
+GUI Git tools on Windows can still work with migrated repos. Use File Explorer to reach the repo on the WSL filesystem, then use the client’s usual right-click menu on that folder:
+
+```text
+\\wsl.localhost\Ubuntu\root\sv-kubernetes\applications\my-app
+```
+
+TortoiseGit and similar tools operate on that path like any other folder Windows can see. You do not need to run them from inside the WSL terminal.
+
+## Update your shortcuts and bookmarks
+
+Update anything that still points at the old `C:\` paths—desktop shortcuts, editor recents, File Explorer bookmarks, team doc links, and so on.
+
+Examples for a repo named `my-app`:
+
+- File Explorer: `\\wsl.localhost\Ubuntu\root\sv-kubernetes\applications\my-app`
+- WSL: `/root/sv-kubernetes/applications/my-app`
+
+The sv-kubernetes **install** folder stays at `C:\sv-kubernetes`. Only your **application and container** project folders move.

--- a/migrate_into_wsl.md
+++ b/migrate_into_wsl.md
@@ -46,20 +46,16 @@ The `sv` tool runs inside **WSL** (a Linux environment on your PC). When your re
 
 5. The script updates your settings so `sv` knows to use the new locations.
 
-6. If you already have repos under `C:\sv-kubernetes\applications` or `C:\sv-kubernetes\containers`, the script will ask whether to **copy** them into WSL. See the next section.
+6. If you already have repos under `C:\sv-kubernetes\applications` or `C:\sv-kubernetes\containers`, the script will ask whether to **copy** them into WSL. See the next section. The script can copy everything from the old folders into WSL for you. **Allowing the migration script to do this automatically can take a _really_ long time**. A few small repos might finish in minutes. Many repos - or large ones with lots of files (particularly node_modules) - can take **hours**.
 
-## Copying your repos
+   When you see the text `Would you like to copy automatically? (y/n)`
 
-The script can copy everything from the old folders into WSL for you. **Allowing the migration script to do this automatically can take a _really_ long time**. A few small repos might finish in minutes. Many repos - or large ones with lots of files (particularly node_modules) - can take **hours**. The script shows progress while it runs.
+   - Press **`y`** to copy your repos automatically.
+   - Press **`n`** to skip copying. Your settings will still be updated, but you will need to put repos in the new place yourself—e.g. run `sv install` again for each project, or copy the folders manually.
 
-When you see:
-
-```text
-Would you like to copy automatically? (y/n)
-```
-
-- Press **`y`** to copy your repos automatically.
-- Press **`n`** to skip copying. Your settings will still be updated, but you will need to put repos in the new place yourself—e.g. run `sv install` again for each project, or copy the folders manually.
+7. Run `exit` to exit the WSL shell.
+8. Run `wsl --shutdown` to shutdown WSL.
+9. Run `wsl` (the `-u root` flag is no longer necessary.)
 
 ## After migration: where to find your repos
 

--- a/scripts/copy_repos.sh
+++ b/scripts/copy_repos.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+# Copy each git repo under SRC_DIR into DEST_DIR/<repo-name>/ using git ignore
+# rules plus the full .git tree. Define copyRepos here, then call it from elsewhere
+# in this script (or after sourcing this file), e.g. copyRepos /sv/applications /sv-wsl/applications-test
+
+copy_repos() {
+	local src_root="${1:?usage: copyRepos SRC_DIR DEST_DIR}"
+	local dest_root="${2:?usage: copyRepos SRC_DIR DEST_DIR}"
+
+	src_root="${src_root%/}"
+	dest_root="${dest_root%/}"
+
+	mkdir -p "$dest_root" || return 1
+
+	local repo name
+	shopt -s nullglob
+	for repo in "$src_root"/*/; do
+		[[ -e "${repo}.git" ]] || continue
+		repo="${repo%/}"
+		name="$(basename "$repo")"
+		mkdir -p "$dest_root/$name" || return 1
+		(
+			cd "$repo" || exit 1
+			(
+				git ls-files -z --cached --others --exclude-standard
+				find .git -print0 2>/dev/null
+			) | rsync -a --files-from=- --from0 ./ "$dest_root/$name/"
+		) || echo "failed: $repo" >&2
+	done
+}
+
+

--- a/scripts/copy_repos.sh
+++ b/scripts/copy_repos.sh
@@ -1,8 +1,5 @@
-#!/usr/bin/env bash
-
 # Copy each git repo under SRC_DIR into DEST_DIR/<repo-name>/ using git ignore
-# rules plus the full .git tree. Define copyRepos here, then call it from elsewhere
-# in this script (or after sourcing this file), e.g. copyRepos /sv/applications /sv-wsl/applications-test
+# rules plus the full .git tree.
 
 copy_repos() {
 	local src_root="${1:?usage: copyRepos SRC_DIR DEST_DIR}"

--- a/scripts/install_sv.sh
+++ b/scripts/install_sv.sh
@@ -29,5 +29,5 @@ ln -sfn /opt/sv/node_modules /node_modules
 chmod +x /sv/sv/sv.js
 ln -sfn /sv/sv/sv.js /usr/bin/sv
 
-mkdir -p /sv/applications
-mkdir -p /sv/containers
+mkdir -p /sv-wsl/applications
+mkdir -p /sv-wsl/containers

--- a/scripts/migrate_wsl.sh
+++ b/scripts/migrate_wsl.sh
@@ -43,12 +43,12 @@ if ((${#app_dirs[@]} + ${#container_dirs[@]} > 0)); then
 
 		echo "Migrating applications..."
 		app_start=$SECONDS
-		rsync --partial --info=progress2 /sv/applications/ /sv-wsl/applications/
+		rsync -aHAXx --partial --info=progress2 /sv/applications/ /sv-wsl/applications/
 		echo "Applications migration completed in $((SECONDS - app_start))s"
 
 		echo "Migrating containers..."
 		container_start=$SECONDS
-		rsync --partial --info=progress2 /sv/containers/ /sv-wsl/containers/
+		rsync -aHAXx --partial --info=progress2 /sv/containers/ /sv-wsl/containers/
 		echo "Containers migration completed in $((SECONDS - container_start))s"
 
 		echo "Total migration time: $((SECONDS - migration_start))s"

--- a/scripts/migrate_wsl.sh
+++ b/scripts/migrate_wsl.sh
@@ -1,3 +1,5 @@
+. /sv/scripts/copy_repos.sh
+
 ln -sfn /root/sv-kubernetes /sv-wsl
 mkdir -p /mnt/wsl/sv-kubernetes
 mkdir -p /root/sv-kubernetes
@@ -43,12 +45,12 @@ if ((${#app_dirs[@]} + ${#container_dirs[@]} > 0)); then
 
 		echo "Migrating applications..."
 		app_start=$SECONDS
-		rsync -aHAXx --partial --info=progress2 /sv/applications/ /sv-wsl/applications/
+		copy_repos /sv/applications /sv-wsl/applications
 		echo "Applications migration completed in $((SECONDS - app_start))s"
 
 		echo "Migrating containers..."
 		container_start=$SECONDS
-		rsync -aHAXx --partial --info=progress2 /sv/containers/ /sv-wsl/containers/
+		copy_repos /sv/containers /sv-wsl/containers
 		echo "Containers migration completed in $((SECONDS - container_start))s"
 
 		echo "Total migration time: $((SECONDS - migration_start))s"
@@ -56,3 +58,4 @@ if ((${#app_dirs[@]} + ${#container_dirs[@]} > 0)); then
 fi
 
 cloud-init single --name cc_write_files --frequency once --file /mnt/c/sv-kubernetes/internal/Ubuntu.user-data
+

--- a/scripts/migrate_wsl.sh
+++ b/scripts/migrate_wsl.sh
@@ -1,61 +1,64 @@
-. /sv/scripts/copy_repos.sh
+if [ ! -f "/sv/.wsl_migrated" ]; then
+	. /sv/scripts/copy_repos.sh
 
-ln -sfn /root/sv-kubernetes /sv-wsl
-mkdir -p /mnt/wsl/sv-kubernetes
-mkdir -p /root/sv-kubernetes
-mount --bind /root/sv-kubernetes /mnt/wsl/sv-kubernetes
+	ln -sfn /root/sv-kubernetes /sv-wsl
+	mkdir -p /mnt/wsl/sv-kubernetes
+	mkdir -p /root/sv-kubernetes
+	mount --bind /root/sv-kubernetes /mnt/wsl/sv-kubernetes
 
-ENV_FILE="/sv/.env"
+	ENV_FILE="/sv/.env"
 
-declare -a ENV_VARS=(
-	"APPS_FOLDER=/sv-wsl/applications"
-	"CONTAINERS_FOLDER=/sv-wsl/containers"
-	"SV_KUBERNETES_MOUNT_PATH=/run/desktop/mnt/host/wsl/sv-kubernetes"
-)
+	declare -a ENV_VARS=(
+		"APPS_FOLDER=/sv-wsl/applications"
+		"CONTAINERS_FOLDER=/sv-wsl/containers"
+		"SV_KUBERNETES_MOUNT_PATH=/run/desktop/mnt/host/wsl/sv-kubernetes"
+	)
 
-mkdir -p "$(dirname "$ENV_FILE")"
-touch "$ENV_FILE"
+	mkdir -p "$(dirname "$ENV_FILE")"
+	touch "$ENV_FILE"
 
-for entry in "${ENV_VARS[@]}"; do
-	key="${entry%%=*}"
-	expected_value="${entry#*=}"
+	for entry in "${ENV_VARS[@]}"; do
+		key="${entry%%=*}"
+		expected_value="${entry#*=}"
 
-	if grep -q "^${key}=" "$ENV_FILE"; then
-		current_value=$(grep "^${key}=" "$ENV_FILE" | tail -n1 | cut -d= -f2-)
-		if [ "$current_value" != "$expected_value" ]; then
-			sed -i "s|^${key}=.*|${key}=${expected_value}|" "$ENV_FILE"
+		if grep -q "^${key}=" "$ENV_FILE"; then
+			current_value=$(grep "^${key}=" "$ENV_FILE" | tail -n1 | cut -d= -f2-)
+			if [ "$current_value" != "$expected_value" ]; then
+				sed -i "s|^${key}=.*|${key}=${expected_value}|" "$ENV_FILE"
+			fi
+		else
+			echo "${key}=${expected_value}" >> "$ENV_FILE"
 		fi
-	else
-		echo "${key}=${expected_value}" >> "$ENV_FILE"
+	done
+
+	shopt -s nullglob
+	app_dirs=(/sv/applications/*/)
+	container_dirs=(/sv/containers/*/)
+	if ((${#app_dirs[@]} + ${#container_dirs[@]} > 0)); then
+		echo "Your ${#app_dirs[@]} application and ${#container_dirs[@]} container repos will now be copied into the WSL filesystem"
+		echo "This could take a REALLY long time depending on the size and complexity of your repos."
+		echo "You can skip this by pressing 'n' and manually copy or install the repos to the WSL filesystem."
+		echo "Would you like to copy automatically? (y/n)"
+		read -n 1 -s -r
+		echo
+		if [[ $REPLY =~ ^[Yy]$ ]]; then
+			migration_start=$SECONDS
+
+			echo "Migrating applications..."
+			app_start=$SECONDS
+			copy_repos /sv/applications /sv-wsl/applications
+			echo "Applications migration completed in $((SECONDS - app_start))s"
+
+			echo "Migrating containers..."
+			container_start=$SECONDS
+			copy_repos /sv/containers /sv-wsl/containers
+			echo "Containers migration completed in $((SECONDS - container_start))s"
+
+			echo "Total migration time: $((SECONDS - migration_start))s"
+		fi
 	fi
-done
 
-shopt -s nullglob
-app_dirs=(/sv/applications/*/)
-container_dirs=(/sv/containers/*/)
-if ((${#app_dirs[@]} + ${#container_dirs[@]} > 0)); then
-	echo "Your ${#app_dirs[@]} application and ${#container_dirs[@]} container repos will now be copied into the WSL filesystem"
-	echo "This could take a REALLY long time depending on the size and complexity of your repos."
-    echo "You can skip this by pressing 'n' and manually copy or install the repos to the WSL filesystem."
-	echo "Would you like to copy automatically? (y/n)"
-	read -n 1 -s -r
-	echo
-	if [[ $REPLY =~ ^[Yy]$ ]]; then
-		migration_start=$SECONDS
+	cloud-init single --name cc_write_files --frequency once --file /mnt/c/sv-kubernetes/internal/Ubuntu.user-data
 
-		echo "Migrating applications..."
-		app_start=$SECONDS
-		copy_repos /sv/applications /sv-wsl/applications
-		echo "Applications migration completed in $((SECONDS - app_start))s"
-
-		echo "Migrating containers..."
-		container_start=$SECONDS
-		copy_repos /sv/containers /sv-wsl/containers
-		echo "Containers migration completed in $((SECONDS - container_start))s"
-
-		echo "Total migration time: $((SECONDS - migration_start))s"
-	fi
+	touch /sv/.wsl_migrated
 fi
-
-cloud-init single --name cc_write_files --frequency once --file /mnt/c/sv-kubernetes/internal/Ubuntu.user-data
-

--- a/scripts/migrate_wsl.sh
+++ b/scripts/migrate_wsl.sh
@@ -1,0 +1,13 @@
+ln -sfn /root/sv-kubernetes /sv-wsl
+mkdir -p /mnt/wsl/sv-kubernetes
+mkdir -p /root/sv-kubernetes
+mount --bind /root/sv-kubernetes /mnt/wsl/sv-kubernetes
+
+cat >> /root/.profile <<'EOF'
+
+export APPS_FOLDER="/sv-wsl/applications"
+export CONTAINERS_FOLDER="/sv-wsl/containers"
+
+EOF
+
+source /root/.profile

--- a/scripts/migrate_wsl.sh
+++ b/scripts/migrate_wsl.sh
@@ -3,11 +3,54 @@ mkdir -p /mnt/wsl/sv-kubernetes
 mkdir -p /root/sv-kubernetes
 mount --bind /root/sv-kubernetes /mnt/wsl/sv-kubernetes
 
-cat >> /root/.profile <<'EOF'
+ENV_FILE="/sv/.env"
 
-export APPS_FOLDER="/sv-wsl/applications"
-export CONTAINERS_FOLDER="/sv-wsl/containers"
+declare -a ENV_VARS=(
+	"APPS_FOLDER=/sv-wsl/applications"
+	"CONTAINERS_FOLDER=/sv-wsl/containers"
+	"SV_KUBERNETES_MOUNT_PATH=/run/desktop/mnt/host/wsl/sv-kubernetes"
+)
 
-EOF
+mkdir -p "$(dirname "$ENV_FILE")"
+touch "$ENV_FILE"
 
-source /root/.profile
+for entry in "${ENV_VARS[@]}"; do
+	key="${entry%%=*}"
+	expected_value="${entry#*=}"
+
+	if grep -q "^${key}=" "$ENV_FILE"; then
+		current_value=$(grep "^${key}=" "$ENV_FILE" | tail -n1 | cut -d= -f2-)
+		if [ "$current_value" != "$expected_value" ]; then
+			sed -i "s|^${key}=.*|${key}=${expected_value}|" "$ENV_FILE"
+		fi
+	else
+		echo "${key}=${expected_value}" >> "$ENV_FILE"
+	fi
+done
+
+shopt -s nullglob
+app_dirs=(/sv/applications/*/)
+container_dirs=(/sv/containers/*/)
+if ((${#app_dirs[@]} + ${#container_dirs[@]} > 0)); then
+	echo "Your ${#app_dirs[@]} application and ${#container_dirs[@]} container repos will now be copied into the WSL filesystem"
+	echo "This could take a REALLY long time depending on the size and complexity of your repos."
+    echo "You can skip this by pressing 'n' and manually copy or install the repos to the WSL filesystem."
+	echo "Would you like to copy automatically? (y/n)"
+	read -n 1 -s -r
+	echo
+	if [[ $REPLY =~ ^[Yy]$ ]]; then
+		migration_start=$SECONDS
+
+		echo "Migrating applications..."
+		app_start=$SECONDS
+		rsync --partial --info=progress2 /sv/applications/ /sv-wsl/applications/
+		echo "Applications migration completed in $((SECONDS - app_start))s"
+
+		echo "Migrating containers..."
+		container_start=$SECONDS
+		rsync --partial --info=progress2 /sv/containers/ /sv-wsl/containers/
+		echo "Containers migration completed in $((SECONDS - container_start))s"
+
+		echo "Total migration time: $((SECONDS - migration_start))s"
+	fi
+fi

--- a/scripts/migrate_wsl.sh
+++ b/scripts/migrate_wsl.sh
@@ -54,3 +54,5 @@ if ((${#app_dirs[@]} + ${#container_dirs[@]} > 0)); then
 		echo "Total migration time: $((SECONDS - migration_start))s"
 	fi
 fi
+
+cloud-init single --name cc_write_files --frequency once --file /mnt/c/sv-kubernetes/internal/Ubuntu.user-data

--- a/scripts/rollback_wsl.sh
+++ b/scripts/rollback_wsl.sh
@@ -1,0 +1,35 @@
+cloud-init single --name cc_write_files --frequency once --file /mnt/c/sv-kubernetes/internal/Ubuntu.user-data.old
+
+shopt -s nullglob
+app_dirs=(/sv-wsl/applications/*/)
+container_dirs=(/sv-wsl/containers/*/)
+if ((${#app_dirs[@]} + ${#container_dirs[@]} > 0)); then
+	echo "Your ${#app_dirs[@]} application and ${#container_dirs[@]} container repos can be copied back to the Windows-mounted paths under /sv"
+	echo "This could take a REALLY long time depending on the size and complexity of your repos."
+	echo "You can skip this by pressing 'n' and manually copy or install the repos under /sv/applications and /sv/containers."
+	echo "Would you like to copy automatically? (y/n)"
+	read -n 1 -s -r
+	echo
+	if [[ $REPLY =~ ^[Yy]$ ]]; then
+		rollback_start=$SECONDS
+
+		echo "Rolling back applications..."
+		app_start=$SECONDS
+		rsync -aHAXx --partial --info=progress2 "/sv-wsl/applications/" /sv/applications/
+		echo "Applications rollback completed in $((SECONDS - app_start))s"
+
+		echo "Rolling back containers..."
+		container_start=$SECONDS
+		rsync -aHAXx --partial --info=progress2 "/sv-wsl/containers/" /sv/containers/
+		echo "Containers rollback completed in $((SECONDS - container_start))s"
+
+		echo "Total rollback copy time: $((SECONDS - rollback_start))s"
+	fi
+fi
+
+cp -f /sv/internal/.env_wsl /sv/.env
+
+umount /mnt/wsl/sv-kubernetes
+rm -rf /root/sv-kubernetes
+rm -rf /mnt/wsl/sv-kubernetes
+rm -f /sv-wsl

--- a/scripts/rollback_wsl.sh
+++ b/scripts/rollback_wsl.sh
@@ -1,3 +1,5 @@
+. /sv/scripts/copy_repos.sh
+
 cloud-init single --name cc_write_files --frequency once --file /mnt/c/sv-kubernetes/internal/Ubuntu.user-data.old
 
 shopt -s nullglob
@@ -15,12 +17,12 @@ if ((${#app_dirs[@]} + ${#container_dirs[@]} > 0)); then
 
 		echo "Rolling back applications..."
 		app_start=$SECONDS
-		rsync -aHAXx --partial --info=progress2 "/sv-wsl/applications/" /sv/applications/
+		copy_repos /sv-wsl/applications /sv/applications
 		echo "Applications rollback completed in $((SECONDS - app_start))s"
 
 		echo "Rolling back containers..."
 		container_start=$SECONDS
-		rsync -aHAXx --partial --info=progress2 "/sv-wsl/containers/" /sv/containers/
+		copy_repos /sv-wsl/containers /sv/containers
 		echo "Containers rollback completed in $((SECONDS - container_start))s"
 
 		echo "Total rollback copy time: $((SECONDS - rollback_start))s"

--- a/scripts/rollback_wsl.sh
+++ b/scripts/rollback_wsl.sh
@@ -1,37 +1,41 @@
-. /sv/scripts/copy_repos.sh
+if [ -f "/sv/.wsl_migrated" ]; then
+    . /sv/scripts/copy_repos.sh
 
-cloud-init single --name cc_write_files --frequency once --file /mnt/c/sv-kubernetes/internal/Ubuntu.user-data.old
+    cloud-init single --name cc_write_files --frequency once --file /mnt/c/sv-kubernetes/internal/Ubuntu.user-data.old
 
-shopt -s nullglob
-app_dirs=(/sv-wsl/applications/*/)
-container_dirs=(/sv-wsl/containers/*/)
-if ((${#app_dirs[@]} + ${#container_dirs[@]} > 0)); then
-	echo "Your ${#app_dirs[@]} application and ${#container_dirs[@]} container repos can be copied back to the Windows-mounted paths under /sv"
-	echo "This could take a REALLY long time depending on the size and complexity of your repos."
-	echo "You can skip this by pressing 'n' and manually copy or install the repos under /sv/applications and /sv/containers."
-	echo "Would you like to copy automatically? (y/n)"
-	read -n 1 -s -r
-	echo
-	if [[ $REPLY =~ ^[Yy]$ ]]; then
-		rollback_start=$SECONDS
+    shopt -s nullglob
+    app_dirs=(/sv-wsl/applications/*/)
+    container_dirs=(/sv-wsl/containers/*/)
+    if ((${#app_dirs[@]} + ${#container_dirs[@]} > 0)); then
+        echo "Your ${#app_dirs[@]} application and ${#container_dirs[@]} container repos can be copied back to the Windows-mounted paths under /sv"
+        echo "This could take a REALLY long time depending on the size and complexity of your repos."
+        echo "You can skip this by pressing 'n' and manually copy or install the repos under /sv/applications and /sv/containers."
+        echo "Would you like to copy automatically? (y/n)"
+        read -n 1 -s -r
+        echo
+        if [[ $REPLY =~ ^[Yy]$ ]]; then
+            rollback_start=$SECONDS
 
-		echo "Rolling back applications..."
-		app_start=$SECONDS
-		copy_repos /sv-wsl/applications /sv/applications
-		echo "Applications rollback completed in $((SECONDS - app_start))s"
+            echo "Rolling back applications..."
+            app_start=$SECONDS
+            copy_repos /sv-wsl/applications /sv/applications
+            echo "Applications rollback completed in $((SECONDS - app_start))s"
 
-		echo "Rolling back containers..."
-		container_start=$SECONDS
-		copy_repos /sv-wsl/containers /sv/containers
-		echo "Containers rollback completed in $((SECONDS - container_start))s"
+            echo "Rolling back containers..."
+            container_start=$SECONDS
+            copy_repos /sv-wsl/containers /sv/containers
+            echo "Containers rollback completed in $((SECONDS - container_start))s"
 
-		echo "Total rollback copy time: $((SECONDS - rollback_start))s"
-	fi
+            echo "Total rollback copy time: $((SECONDS - rollback_start))s"
+        fi
+    fi
+
+    cp -f /sv/internal/.env_wsl /sv/.env
+
+    umount /mnt/wsl/sv-kubernetes
+    rm -rf /root/sv-kubernetes
+    rm -rf /mnt/wsl/sv-kubernetes
+    rm -f /sv-wsl
+
+    rm -f /sv/.wsl_migrated
 fi
-
-cp -f /sv/internal/.env_wsl /sv/.env
-
-umount /mnt/wsl/sv-kubernetes
-rm -rf /root/sv-kubernetes
-rm -rf /mnt/wsl/sv-kubernetes
-rm -f /sv-wsl

--- a/setup_wsl.sh
+++ b/setup_wsl.sh
@@ -3,9 +3,7 @@
 ln -sfn /mnt/c/sv-kubernetes /sv
 mkdir -p /root/{.kube,.config}
 mkdir -p /mnt/c/sv-kubernetes/internal/gcloud
-ln -sfn /home/vagrant/.kube/config /root/.kube/config
 ln -sfn /mnt/c/sv-kubernetes/internal/gcloud /root/.config/gcloud
-chmod 600 /home/vagrant/.kube/config
 chmod 600 /root/.kube/config
 cp /home/vagrant/.bashrc /root/.bashrc
 

--- a/setup_wsl.sh
+++ b/setup_wsl.sh
@@ -12,6 +12,8 @@ cp /home/vagrant/.bashrc /root/.bashrc
 . /sv/scripts/errorHandler.sh
 . /sv/scripts/requireRoot.sh
 
+. /sv/scripts/migrate_wsl.sh
+
 . /sv/scripts/install_misc.sh
 . /sv/scripts/install_sv.sh
 . /sv/scripts/install_github.sh

--- a/sv/constants.js
+++ b/sv/constants.js
@@ -1,8 +1,11 @@
 const fs = require("fs");
-
+console.log(process.env.APPS_FOLDER);
+process.exit();
 /** Folder path where applications are found. */
 module.exports.APPS_FOLDER = process.env.APPS_FOLDER || "/sv/applications";
+// module.exports.APPS_FOLDER_WSL = process.env.APPS_FOLDER_WSL || "/sv-wsl/applications";
 module.exports.CONTAINERS_FOLDER = "/sv/containers";
+// module.exports.CONTAINERS_FOLDER_WSL = "/sv-wsl/containers";
 module.exports.GRAPH_URL = "https://graphql.simpleviewinc.com";
 module.exports.REFRESH_TOKEN_PATH = "/sv/internal/refresh_token";
 module.exports.AUTH_TOKEN_PATH = "/sv/internal/auth_token";
@@ -12,3 +15,4 @@ module.exports.LOCAL_CONTEXT_DESKTOP = "docker-desktop";
 module.exports.IS_DOCKER_DESKTOP = process.env.IS_DOCKER_DESKTOP === "true" || fs.existsSync("/etc/wsl.conf");
 /** Location where Kubernetes can mount content */
 module.exports.SV_KUBERNETES_MOUNT_PATH = process.env.SV_KUBERNETES_MOUNT_PATH ?? `/run/desktop/mnt/host/c/sv-kubernetes`;
+// module.exports.SV_KUBERNETES_MOUNT_PATH_WSL = process.env.SV_KUBERNETES_MOUNT_PATH_WSL ?? `/run/desktop/mnt/host/wsl/sv-kubernetes`;

--- a/sv/constants.js
+++ b/sv/constants.js
@@ -1,11 +1,16 @@
+const path = require("path");
+const dotenv = require("dotenv");
 const fs = require("fs");
-console.log(process.env.APPS_FOLDER);
-process.exit();
+const env = require("env-var");
+
+dotenv.config({
+    path: path.resolve(__dirname, "../.env"),
+    quiet: true,
+});
+
 /** Folder path where applications are found. */
-module.exports.APPS_FOLDER = process.env.APPS_FOLDER || "/sv/applications";
-// module.exports.APPS_FOLDER_WSL = process.env.APPS_FOLDER_WSL || "/sv-wsl/applications";
-module.exports.CONTAINERS_FOLDER = "/sv/containers";
-// module.exports.CONTAINERS_FOLDER_WSL = "/sv-wsl/containers";
+module.exports.APPS_FOLDER = env.get("APPS_FOLDER").default("/sv/applications").asString();
+module.exports.CONTAINERS_FOLDER = env.get("CONTAINERS_FOLDER").default("/sv/containers").asString();
 module.exports.GRAPH_URL = "https://graphql.simpleviewinc.com";
 module.exports.REFRESH_TOKEN_PATH = "/sv/internal/refresh_token";
 module.exports.AUTH_TOKEN_PATH = "/sv/internal/auth_token";
@@ -14,5 +19,4 @@ module.exports.LOCAL_CONTEXT_DESKTOP = "docker-desktop";
 // fs.existsSync is a hack until we have all devs off the wsl-variant
 module.exports.IS_DOCKER_DESKTOP = process.env.IS_DOCKER_DESKTOP === "true" || fs.existsSync("/etc/wsl.conf");
 /** Location where Kubernetes can mount content */
-module.exports.SV_KUBERNETES_MOUNT_PATH = process.env.SV_KUBERNETES_MOUNT_PATH ?? `/run/desktop/mnt/host/c/sv-kubernetes`;
-// module.exports.SV_KUBERNETES_MOUNT_PATH_WSL = process.env.SV_KUBERNETES_MOUNT_PATH_WSL ?? `/run/desktop/mnt/host/wsl/sv-kubernetes`;
+module.exports.SV_KUBERNETES_MOUNT_PATH = env.get("SV_KUBERNETES_MOUNT_PATH").default("/run/desktop/mnt/host/c/sv-kubernetes").asString();

--- a/sv/sv.js
+++ b/sv/sv.js
@@ -749,6 +749,11 @@ scripts.debug = function(args) {
 		console.log("");
 	}
 
+	block("Constants", () => {
+		Object.entries(constants).forEach(([key, value]) => {
+			console.log(`${key}: ${value}`);
+		});
+	});
 	block("Memory Utilized", () => exec(`sudo free -m`));
 	block("Kubernetes Version", () => exec(`kubectl version --short`));
 	block("Docker Version", () => exec(`docker -v`));

--- a/sv/sv.js
+++ b/sv/sv.js
@@ -113,11 +113,11 @@ scripts.install = async function(args) {
 	}
 
 	const resultType = {
-		app : "applications",
-		container : "containers"
+		app : constants.APPS_FOLDER,
+		container : constants.CONTAINERS_FOLDER
 	}
 
-	const path = `/sv/${resultType[type]}/${name}`;
+	const path = `${resultType[type]}/${name}`;
 
 	if (!fs.existsSync(path)) {
 		// initialize the repo from sv origin master branch


### PR DESCRIPTION
## Summary
Move application and container repos from the Windows filesystem (`C:\sv-kubernetes\...`) into WSL-native storage for better performance, while keeping the sv-kubernetes tooling checkout on `C:\`.
- **New installs:** WSL layout and `.env` paths are applied automatically via `setup_wsl.sh` (which sources `scripts/migrate_wsl.sh`).
- **Existing installs:** Optional migration via `scripts/migrate_wsl.sh` and [migrate_into_wsl.md](migrate_into_wsl.md). No forced deadline—defaults still point at `/sv/applications` and `/sv/containers` until `.env` is updated.
## WSL provisioning changes
- Cloud-init (`internal/Ubuntu.user-data` → `%UserProfile%\.cloud-init\`) still creates a **`vagrant`** user (required for Ubuntu to provision).
- **`[user] default=root`** so day-to-day use is as root (matches `wsl -u root` in docs).
- **`/etc/wsl.conf` is written on first boot**; `[boot] command` and default user take effect only after a full restart—hence `wsl --shutdown` in [install_windows.md](install_windows.md) before running `setup_wsl.sh`.
- Removed symlink of `/root/.kube/config` → vagrant’s config; with root as default, Docker Desktop/kubeconfig land under root.
## Migration (`scripts/migrate_wsl.sh`)
- Creates `/root/sv-kubernetes` (apps/containers) and `/sv-wsl` symlink.
- Bind-mounts to `/mnt/wsl/sv-kubernetes` for Docker Desktop host paths.
- Writes `/sv/.env` keys read by `sv/constants.js` (`APPS_FOLDER`, `CONTAINERS_FOLDER`, `SV_KUBERNETES_MOUNT_PATH`) without breaking installs that never migrate (defaults unchanged).
- Optionally **rsync**s existing repos from `/sv/applications` and `/sv/containers`; prompt allows skip (copy can take hours—see migration guide).
## Other
- `sv debug` prints resolved constants.
- Install docs: post-install shutdown, `whoami` → `root`, WSL version note (tested through 2.7.3.0).
## How to test
### New install
- [ ] `windows_init.ps1` → install WSL per `install_windows.md` (including shutdown) → `wsl -u root` → `bash /mnt/c/sv-kubernetes/setup_wsl.sh`
- [ ] `whoami` is `root`; repos under `/root/sv-kubernetes/{applications,containers}`; `sv debug` shows WSL paths and mount path.
### Existing install (no copy)
- [ ] `wsl -u root` → `bash /sv/scripts/migrate_wsl.sh` → answer `n` at rsync prompt
- [ ] `/sv/.env` updated; `sv install` / `sv start` use new paths.
### Existing install (with copy)
- [ ] Same with `y` when repos exist under old paths; verify rsync progress and final locations.
### Non-migrated (regression)
- [ ] No `.env` overrides (or old values): `sv` still uses `/sv/applications` and `/sv/containers`.