### PR TITLE
Replace cloud-init wsl.conf step with write_wsl_conf; use APPS_FOLDER in sv

### DIFF
--- a/scripts/migrate_wsl.sh
+++ b/scripts/migrate_wsl.sh
@@ -1,5 +1,6 @@
 if [ ! -f "/sv/.wsl_migrated" ]; then
 	. /sv/scripts/copy_repos.sh
+	. /sv/scripts/write_wsl_conf.sh
 
 	ln -sfn /root/sv-kubernetes /sv-wsl
 	mkdir -p /mnt/wsl/sv-kubernetes
@@ -58,7 +59,7 @@ if [ ! -f "/sv/.wsl_migrated" ]; then
 		fi
 	fi
 
-	cloud-init single --name cc_write_files --frequency once --file /mnt/c/sv-kubernetes/internal/Ubuntu.user-data
+	write_wsl_conf /sv/internal/Ubuntu.user-data
 
 	touch /sv/.wsl_migrated
 fi

--- a/scripts/rollback_wsl.sh
+++ b/scripts/rollback_wsl.sh
@@ -1,7 +1,8 @@
 if [ -f "/sv/.wsl_migrated" ]; then
     . /sv/scripts/copy_repos.sh
+    . /sv/scripts/write_wsl_conf.sh
 
-    cloud-init single --name cc_write_files --frequency once --file /mnt/c/sv-kubernetes/internal/Ubuntu.user-data.old
+    write_wsl_conf /sv/internal/Ubuntu.user-data.old
 
     shopt -s nullglob
     app_dirs=(/sv-wsl/applications/*/)

--- a/scripts/write_wsl_conf.sh
+++ b/scripts/write_wsl_conf.sh
@@ -1,5 +1,4 @@
-#!/usr/bin/env bash
-set -euo pipefail
+# Write the WSL configuration file from a user-data based YAML file
 
 write_wsl_conf() {
   local yaml_path="${1:?usage: write_wsl_conf <path-to-yaml>}"

--- a/scripts/write_wsl_conf.sh
+++ b/scripts/write_wsl_conf.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+write_wsl_conf() {
+  local yaml_path="${1:?usage: write_wsl_conf <path-to-yaml>}"
+  python3 - "$yaml_path" <<'PY' >/etc/wsl.conf
+import sys
+import yaml
+
+with open(sys.argv[1]) as f:
+    data = yaml.safe_load(f)
+
+for item in data.get("write_files") or []:
+    if item.get("path") == "/etc/wsl.conf" and "content" in item:
+        print(item["content"], end="")
+        raise SystemExit(0)
+raise SystemExit("no write_files entry with path /etc/wsl.conf and content")
+PY
+}
+

--- a/sv/sv.js
+++ b/sv/sv.js
@@ -238,7 +238,7 @@ scripts.start = async function(args) {
 	const deploymentName = flags.alias !== undefined ? flags.alias : applicationName;
 
 	const rootKubeFolder = constants.SV_KUBERNETES_MOUNT_PATH;
-	const appFolder = `/sv/applications/${applicationName}`;
+	const appFolder = `${constants.APPS_FOLDER}/${applicationName}`;
 	const chartFolder = `${appFolder}/chart`;
 	const containerFolder = `${appFolder}/containers`;
 	const externalApplicationFolder = `${rootKubeFolder}/applications/${applicationName}`;
@@ -650,7 +650,7 @@ scripts.script = function(args) {
 
 	validateApp(applicationName);
 
-	const appPath = `/sv/applications/${applicationName}`;
+	const appPath = `${constants.APPS_FOLDER}/${applicationName}`;
 
 	const envVars = {
 		SV_APP_PATH : appPath,


### PR DESCRIPTION
- Stops calling `cloud-init single` during WSL migrate and rollback because it was failing unpredictably; migration and rollback now source `write_wsl_conf.sh` and call `write_wsl_conf` with the user-data YAML under `/sv/internal/` instead of a Windows mount path.
- Adds `scripts/write_wsl_conf.sh`, which uses Python 3 and `yaml.safe_load` to read the `write_files` list, find the entry whose `path` is `/etc/wsl.conf`, and write that `content` to `/etc/wsl.conf`.
- Updates `sv/sv.js` so `scripts.start` and `scripts.script` resolve application directories with `${constants.APPS_FOLDER}` instead of a hard-coded `/sv/applications/...` prefix.