### PR TITLE
Documentation + setup fixes for MacOS

### DIFF
--- a/install_mac.md
+++ b/install_mac.md
@@ -83,5 +83,7 @@ To install and start any other repo, the general form is:
     * Your sv-kubernetes repository is improperly cloned and the line endings are being converted. You need to ensure that the getting setting `core.autocrlf=false` and then delete and re-clone the repository.
 * Is Docker Desktop running?
     * Start it, ensure that it says Engine Running and Kubernetes Running in the bottom left. If it doesn't, check the Docker Engine installations steps above.
+* Services at `192.168.50.100:PORT` are unreachable.
+    * `unix_init.sh` adds a loopback alias for `192.168.50.100` on `lo0`. Confirm it exists by running `ifconfig lo0` in Terminal — you should see an `inet 192.168.50.100` entry. If it is missing, re-run `unix_init.sh` (with `sudo`) and reboot.
 * `hostPort` entries are failing because a low port cannot be used.
     * When use hostPort you can also declare the service as of `type: LoadBalancer` and do not declare an IP address. It will still be accessible at the main `192.168.50.100:PORT`.

--- a/install_mac.md
+++ b/install_mac.md
@@ -2,20 +2,16 @@
 
 Running sv-kubernetes MacOS (ARM64) requires the following features and systems:
 
-* Unix Terminal setup to use Bash shell
+* Unix Terminal running either Bash or Zsh.
 * Ability to run sudo in Terminal and install software as Admin.
 * Git installed and accessible in Terminal
 * Docker Engine - See instructions below for installation.
-
-**_IMPORTANT: This setup on MacOS have been tested with Docker Desktop version `4.37.2`. If you are facing mounts issues with a newer version please downgrade your Docker Desktop installation to the verified version._**
 
 
 ## Checkout Repo
 
 ```
-cd /Users/Shared
-git clone https://github.com/simpleviewinc/sv-kubernetes.git
-cd sv-kubernetes
+git clone https://github.com/simpleviewinc/sv-kubernetes.git && cd sv-kubernetes
 ```
 
 
@@ -23,37 +19,59 @@ cd sv-kubernetes
 
 [Click here](https://docs.docker.com/desktop/setup/install/mac-install/) to download the latest version of **_Docker Desktop for Mac with Apple silicon_**.
 
-After installation, follow the instructions to [Enable Kubernetes](https://docs.docker.com/desktop/features/kubernetes/#install-and-turn-on-kubernetes).
+After installation, enable Kubernetes. **IMPORTANT: Choose the `kubeadm` provisioner before turning Kubernetes on** — this is required for sv-kubernetes:
+
+1. Open Docker Desktop **Settings → Kubernetes**.
+2. Under **Cluster settings**, select **`kubeadm`** as the provisioner (do NOT use `kind`).
+3. Check **Enable Kubernetes** and click **Apply & restart**.
 
 At the bottom of the screen in docker desktop you should see `Engine Running` and `Kubernetes Running`.
 
 
 ## Setup Environment
 
-In Terminal:
+From the repository root (where you ran `cd sv-kubernetes` above):
 
 ```
-sudo bash /Users/Shared/sv-kubernetes/scripts/unix_init.sh ${USER} && . ~/.bash_aliases
+sudo bash scripts/unix_init.sh ${USER} && . ~/.bash_aliases
 ```
 
-and it should output `Success` at the end.
+and it should output `Success` at the end. The `&& . ~/.bash_aliases` loads the `sv` aliases into your current shell. The script also wires the aliases into both `~/.bash_profile` and `~/.zshrc`, so they persist whether you use Bash or Zsh in new terminals.
 
 * Note: If the script prompted you to create a `github_key` you will need to upload it to Github so that it can be utilized.
     * The Github docs are located [Here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account?platform=linux&tool=webui)
     * Remember your public keyfile is named `github_key.pub` and not id_ed25519.pub so you’ll need to adjust the instructions.
     * The name of the key in Github's UI doesn’t technically matter, but the best practice is to name it with the use-case, so sv-kubernetes might be practical.
 
-```
-# enter the docker cli, this will build the container and start it, it can take some time
-sv-kube-enter
-# login to gcloud
-gcloud auth login --update-adc --no-launch-browser
-```
-
 
 ## Usage
 
-From here install and start the repos you desire:
+`sv-kube-enter` builds (first run only) and drops you into the CLI container; the `sv` commands below all run inside it.
+
+```
+# Enter the CLI container. The first run builds the image and can take a while.
+sv-kube-enter
+
+# Authenticate gcloud for Application Default Credentials (used to decrypt secrets),
+# then authenticate the sv tooling.
+gcloud auth login --update-adc --no-launch-browser # use your simpleviewinc.com account
+sv authLogin # use your dc.gdi account
+
+# Install and start the proxy and cms-kube.
+sv install cms-kube --branch=staging
+sv start sv-kube-proxy local --build
+sv start cms-kube local --build
+
+# Wait until every pod reports READY n/n.
+kubectl get all
+
+# Enter the cms-kube pod and set up the client.
+sv enterPod cms-kube
+sv setupClient rc
+sv startClient rc
+```
+
+To install and start any other repo, the general form is:
 
 * `sv install REPO`
 * `sv start REPO local --build`
@@ -65,7 +83,5 @@ From here install and start the repos you desire:
     * Your sv-kubernetes repository is improperly cloned and the line endings are being converted. You need to ensure that the getting setting `core.autocrlf=false` and then delete and re-clone the repository.
 * Is Docker Desktop running?
     * Start it, ensure that it says Engine Running and Kubernetes Running in the bottom left. If it doesn't, check the Docker Engine installations steps above.
-* Is the WSL using the proper IP address?
-    * In windows command prompt run `ifconfig`. There should be an entry for `lo0:` with `inet 192.168.50.100`. If it is not, then you need to ensure you ran `unix_init.sh`. Re-run that script as Admin, and then reboot.
 * `hostPort` entries are failing because a low port cannot be used.
     * When use hostPort you can also declare the service as of `type: LoadBalancer` and do not declare an IP address. It will still be accessible at the main `192.168.50.100:PORT`.

--- a/install_mac.md
+++ b/install_mac.md
@@ -85,5 +85,8 @@ To install and start any other repo, the general form is:
     * Start it, ensure that it says Engine Running and Kubernetes Running in the bottom left. If it doesn't, check the Docker Engine installations steps above.
 * Services at `192.168.50.100:PORT` are unreachable.
     * `unix_init.sh` adds a loopback alias for `192.168.50.100` on `lo0`. Confirm it exists by running `ifconfig lo0` in Terminal — you should see an `inet 192.168.50.100` entry. If it is missing, re-run `unix_init.sh` (with `sudo`) and reboot.
+* cms-kube client returns HTTP **502**, nginx vhost exists, but `/tmp/<client>.socket` is missing.
+    * The Node worker failed to resolve `cms-redis.kube.simpleview.io` / `cms-mongo-local.kube.simpleview.io` / `cms-solr-local.kube.simpleview.io` inside the bundle pod. Public DNS points those names at `192.168.50.100`; some home-router resolvers strip that private A record (DNS rebinding protection), so CoreDNS forwarding from the pod gets an empty answer.
+    * Full diagnosis and an ephemeral bundle `/etc/hosts` fix: workspace doc `docs/local-cms-kube-worker-dns.md` (cms-migration umbrella).
 * `hostPort` entries are failing because a low port cannot be used.
     * When use hostPort you can also declare the service as of `type: LoadBalancer` and do not declare an IP address. It will still be accessible at the main `192.168.50.100:PORT`.

--- a/scripts/unix_init.sh
+++ b/scripts/unix_init.sh
@@ -111,7 +111,9 @@ fi
 ln -sfn ${SV_KUBERNETES_PATH}/scripts/unix_profile.sh ${USER_PROFILE_DIR}/.bash_aliases
 
 cp ${SV_KUBERNETES_PATH}/internal/${INTERNAL_ENV_FILE} ${SV_KUBERNETES_PATH}/.env
-sed -i -e '/SV_KUBERNETES_MOUNT_PATH=/d' ${SV_KUBERNETES_PATH}/.env
+# Strip any existing mount path line, then append the resolved one. Using grep + a temp
+# file instead of `sed -i` avoids the BSD/GNU `-i` difference (BSD sed leaves a .env-e backup).
+grep -v 'SV_KUBERNETES_MOUNT_PATH=' ${SV_KUBERNETES_PATH}/.env > ${SV_KUBERNETES_PATH}/.env.tmp && mv ${SV_KUBERNETES_PATH}/.env.tmp ${SV_KUBERNETES_PATH}/.env
 echo "SV_KUBERNETES_MOUNT_PATH=${SV_KUBERNETES_PATH}" >> ${SV_KUBERNETES_PATH}/.env
 
 echo "Success"

--- a/scripts/unix_init.sh
+++ b/scripts/unix_init.sh
@@ -100,6 +100,14 @@ touch ${USER_PROFILE_DIR}/${BASH_USER_SCRIPT}
 if ! grep -qi '. ~/.bash_aliases' ${USER_PROFILE_DIR}/${BASH_USER_SCRIPT}; then
 	echo 'if [ -f ~/.bash_aliases ]; then . ~/.bash_aliases; fi' >> ${USER_PROFILE_DIR}/${BASH_USER_SCRIPT}
 fi
+if [[ "${ARCH}" == "arm64" ]]; then
+	ZSHRC_PATH="${USER_PROFILE_DIR}/.zshrc"
+	touch "${ZSHRC_PATH}"
+	if ! grep -qi '. ~/.bash_aliases' "${ZSHRC_PATH}"; then
+		echo 'if [ -f ~/.bash_aliases ]; then . ~/.bash_aliases; fi' >> "${ZSHRC_PATH}"
+	fi
+	chown "${USERNAME}" "${ZSHRC_PATH}"
+fi
 ln -sfn ${SV_KUBERNETES_PATH}/scripts/unix_profile.sh ${USER_PROFILE_DIR}/.bash_aliases
 
 cp ${SV_KUBERNETES_PATH}/internal/${INTERNAL_ENV_FILE} ${SV_KUBERNETES_PATH}/.env

--- a/scripts/unix_profile.sh
+++ b/scripts/unix_profile.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-SV_KUBERNETES_PATH=$(realpath $(dirname $(realpath ${BASH_SOURCE[0]}))/..)
+SV_KUBERNETES_PATH=$(realpath $(dirname $(realpath ${BASH_SOURCE[0]:-$0}))/..)
 ARCH=$(arch | sed s/aarch64/arm64/ | sed s/x86_64/amd64/)
 
 function sv_kubernetes_container_exists {
@@ -27,7 +27,7 @@ function docker_run_sv_kubernetes {
 	docker compose --project-directory ${SV_KUBERNETES_PATH} build cli
 
 	echo "Running sv-kubernetes container"
-	docker compose --project-directory ${SV_KUBERNETES_PATH} up -d
+	docker compose --project-directory ${SV_KUBERNETES_PATH} up -d cli
 }
 
 function docker_stop_sv_kubernetes {
@@ -46,7 +46,7 @@ BASE_ROOT="${SV_KUBERNETES_PATH}/applications"
 TARGET_FILE_NAME="install_aliases.sh"
 
 # Source each file
-for file in $(ls ${BASE_ROOT}/*/scripts/${TARGET_FILE_NAME}); do
+for file in $(find "${BASE_ROOT}" -maxdepth 3 -name "${TARGET_FILE_NAME}" 2>/dev/null); do
 	echo "Loading user profile script ${file} ..."
 	. "${file}"
 done


### PR DESCRIPTION
Fixes encountered setting up sv-kubernetes on macOS (Apple silicon) with zsh.

- added zsh compatibility in `unix_profile.sh`/`unix_init.sh`
- `unix_init.sh`: rewrite `.env` with `grep` + temp file instead of `sed -i -e`, which on BSD sed (macOS) leaves a stray `.env-e` backup. This file is shared with WSL, and while the output should be identical, but it's possibly worth a quick WSL sanity-check before merge.
- assorted docs changes